### PR TITLE
perf: Webpack最適化を有効化（minimize, code splitting, tree shaking）

### DIFF
--- a/application/client/package.json
+++ b/application/client/package.json
@@ -5,7 +5,7 @@
   "license": "MPL-2.0",
   "author": "CyberAgent, Inc.",
   "scripts": {
-    "build": "NODE_ENV=development webpack",
+    "build": "NODE_ENV=production webpack",
     "typecheck": "tsc"
   },
   "dependencies": {

--- a/application/client/src/index.html
+++ b/application/client/src/index.html
@@ -4,8 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CaX</title>
-    <script src="/scripts/main.js"></script>
-    <link rel="stylesheet" href="/styles/main.css" />
     <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4.2.1"></script>
     <style type="text/tailwindcss">
       @layer base {

--- a/application/client/webpack.config.js
+++ b/application/client/webpack.config.js
@@ -25,7 +25,7 @@ const config = {
     ],
     static: [PUBLIC_PATH, UPLOAD_PATH],
   },
-  devtool: "inline-source-map",
+  devtool: false,
   entry: {
     main: [
       "core-js",
@@ -36,7 +36,7 @@ const config = {
       path.resolve(SRC_PATH, "./index.tsx"),
     ],
   },
-  mode: "none",
+  mode: "production",
   module: {
     rules: [
       {
@@ -60,10 +60,9 @@ const config = {
   },
   output: {
     chunkFilename: "scripts/chunk-[contenthash].js",
-    chunkFormat: false,
-    filename: "scripts/[name].js",
+    filename: "scripts/[name]-[contenthash].js",
     path: DIST_PATH,
-    publicPath: "auto",
+    publicPath: "/",
     clean: true,
   },
   plugins: [
@@ -77,7 +76,7 @@ const config = {
       BUILD_DATE: new Date().toISOString(),
       // Heroku では SOURCE_VERSION 環境変数から commit hash を参照できます
       COMMIT_HASH: process.env.SOURCE_VERSION || "",
-      NODE_ENV: "development",
+      NODE_ENV: "production",
     }),
     new MiniCssExtractPlugin({
       filename: "styles/[name].css",
@@ -91,7 +90,7 @@ const config = {
       ],
     }),
     new HtmlWebpackPlugin({
-      inject: false,
+      inject: "body",
       template: path.resolve(SRC_PATH, "./index.html"),
     }),
   ],
@@ -128,14 +127,18 @@ const config = {
     },
   },
   optimization: {
-    minimize: false,
-    splitChunks: false,
-    concatenateModules: false,
-    usedExports: false,
-    providedExports: false,
-    sideEffects: false,
+    minimize: true,
+    splitChunks: {
+      chunks: "all",
+    },
+    concatenateModules: true,
+    usedExports: true,
+    providedExports: true,
+    sideEffects: true,
   },
-  cache: false,
+  cache: {
+    type: "filesystem",
+  },
   ignoreWarnings: [
     {
       module: /@ffmpeg/,


### PR DESCRIPTION
## Summary
- Webpack の最適化オプション（minimize, splitChunks, usedExports, concatenateModules）を有効化
- `mode: "production"`, `devtool: false`, `NODE_ENV=production` に変更
- HtmlWebpackPlugin で script を自動注入（`inject: "body"`）
- ファイルシステムキャッシュでリビルド高速化

## ビルド結果
| | Before | After |
|---|--------|-------|
| main.js | 108MB（1ファイル） | 245KB |
| vendors | - | 73MB（WASM含む、#7で対応） |
| CSS | 82KB | 30KB |
| ビルド時間 | 6s | 42s（初回）/ 2.7s（キャッシュ） |

## Test plan
- [x] `pnpm build` が成功すること
- [x] `pnpm start` でアプリが正常起動すること
- [x] HTML に script タグが正しく挿入されること
- [ ] scoring-tool でスコアが改善すること

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)