### PR TITLE
perf: 不要なポリフィル・レガシーライブラリを除去する

### DIFF
--- a/application/client/src/components/crok/ChatInput.tsx
+++ b/application/client/src/components/crok/ChatInput.tsx
@@ -1,4 +1,3 @@
-import Bluebird from "bluebird";
 import kuromoji, { type Tokenizer, type IpadicFeatures } from "kuromoji";
 import {
   useEffect,
@@ -96,14 +95,11 @@ export const ChatInput = ({ isStreaming, onSendMessage }: Props) => {
   useEffect(() => {
     let mounted = true;
 
-    const init = async () => {
-      const builder = Bluebird.promisifyAll(kuromoji.builder({ dicPath: "/dicts" }));
-      const nextTokenizer = await builder.buildAsync();
-      if (mounted) {
+    kuromoji.builder({ dicPath: "/dicts" }).build((err, nextTokenizer) => {
+      if (!err && mounted) {
         setTokenizer(nextTokenizer);
       }
-    };
-    init();
+    });
 
     return () => {
       mounted = false;

--- a/application/client/src/components/direct_message/DirectMessageListPage.tsx
+++ b/application/client/src/components/direct_message/DirectMessageListPage.tsx
@@ -1,4 +1,4 @@
-import moment from "moment";
+import { timeAgo } from "@web-speed-hackathon-2026/client/src/utils/date_format";
 import { useCallback, useEffect, useState } from "react";
 
 import { Button } from "@web-speed-hackathon-2026/client/src/components/foundation/Button";
@@ -100,7 +100,7 @@ export const DirectMessageListPage = ({ activeUser, newDmModalId }: Props) => {
                             className="text-cax-text-subtle text-xs"
                             dateTime={lastMessage.createdAt}
                           >
-                            {moment(lastMessage.createdAt).locale("ja").fromNow()}
+                            {timeAgo(lastMessage.createdAt)}
                           </time>
                         )}
                       </div>

--- a/application/client/src/components/direct_message/DirectMessagePage.tsx
+++ b/application/client/src/components/direct_message/DirectMessagePage.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import moment from "moment";
+import { formatTime } from "@web-speed-hackathon-2026/client/src/utils/date_format";
 import {
   ChangeEvent,
   useCallback,
@@ -141,7 +141,7 @@ export const DirectMessagePage = ({
                 </p>
                 <div className="flex gap-1 text-xs">
                   <time dateTime={message.createdAt}>
-                    {moment(message.createdAt).locale("ja").format("HH:mm")}
+                    {formatTime(message.createdAt)}
                   </time>
                   {isActiveUserSend && message.isRead && (
                     <span className="text-cax-text-muted">既読</span>

--- a/application/client/src/components/foundation/SoundWaveSVG.tsx
+++ b/application/client/src/components/foundation/SoundWaveSVG.tsx
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import { useEffect, useRef, useState } from "react";
 
 interface ParsedData {
@@ -6,24 +5,29 @@ interface ParsedData {
   peaks: number[];
 }
 
+/** 音声データから波形のピーク値を計算する */
 async function calculate(data: ArrayBuffer): Promise<ParsedData> {
   const audioCtx = new AudioContext();
 
   // 音声をデコードする
   const buffer = await audioCtx.decodeAudioData(data.slice(0));
   // 左の音声データの絶対値を取る
-  const leftData = _.map(buffer.getChannelData(0), Math.abs);
+  const leftData = Array.from(buffer.getChannelData(0), Math.abs);
   // 右の音声データの絶対値を取る
-  const rightData = _.map(buffer.getChannelData(1), Math.abs);
+  const rightData = Array.from(buffer.getChannelData(1), Math.abs);
 
   // 左右の音声データの平均を取る
-  const normalized = _.map(_.zip(leftData, rightData), _.mean);
+  const normalized = leftData.map((l, i) => (l + (rightData[i] ?? 0)) / 2);
   // 100 個の chunk に分ける
-  const chunks = _.chunk(normalized, Math.ceil(normalized.length / 100));
-  // chunk ごとに平均を取る
-  const peaks = _.map(chunks, _.mean);
+  const chunkSize = Math.ceil(normalized.length / 100);
+  const peaks: number[] = [];
+  for (let i = 0; i < normalized.length; i += chunkSize) {
+    const chunk = normalized.slice(i, i + chunkSize);
+    const mean = chunk.reduce((sum, v) => sum + v, 0) / chunk.length;
+    peaks.push(mean);
+  }
   // chunk の平均の中から最大値を取る
-  const max = _.max(peaks) ?? 0;
+  const max = Math.max(...peaks, 0);
 
   return { max, peaks };
 }

--- a/application/client/src/components/post/CommentItem.tsx
+++ b/application/client/src/components/post/CommentItem.tsx
@@ -1,4 +1,4 @@
-import moment from "moment";
+import { formatDateLong, toISOString } from "@web-speed-hackathon-2026/client/src/utils/date_format";
 
 import { Link } from "@web-speed-hackathon-2026/client/src/components/foundation/Link";
 import { TranslatableText } from "@web-speed-hackathon-2026/client/src/components/post/TranslatableText";
@@ -42,8 +42,8 @@ export const CommentItem = ({ comment }: Props) => {
             <TranslatableText text={comment.text} />
           </div>
           <p className="text-cax-text-muted pt-1 text-xs">
-            <time dateTime={moment(comment.createdAt).toISOString()}>
-              {moment(comment.createdAt).locale("ja").format("LL")}
+            <time dateTime={toISOString(comment.createdAt)}>
+              {formatDateLong(comment.createdAt)}
             </time>
           </p>
         </div>

--- a/application/client/src/components/post/PostItem.tsx
+++ b/application/client/src/components/post/PostItem.tsx
@@ -1,4 +1,4 @@
-import moment from "moment";
+import { formatDateLong, toISOString } from "@web-speed-hackathon-2026/client/src/utils/date_format";
 
 import { Link } from "@web-speed-hackathon-2026/client/src/components/foundation/Link";
 import { ImageArea } from "@web-speed-hackathon-2026/client/src/components/post/ImageArea";
@@ -67,8 +67,8 @@ export const PostItem = ({ post }: Props) => {
           ) : null}
           <p className="mt-2 text-sm sm:mt-4">
             <Link className="text-cax-text-muted hover:underline" to={`/posts/${post.id}`}>
-              <time dateTime={moment(post.createdAt).toISOString()}>
-                {moment(post.createdAt).locale("ja").format("LL")}
+              <time dateTime={toISOString(post.createdAt)}>
+                {formatDateLong(post.createdAt)}
               </time>
             </Link>
           </p>

--- a/application/client/src/components/timeline/TimelineItem.tsx
+++ b/application/client/src/components/timeline/TimelineItem.tsx
@@ -1,4 +1,4 @@
-import moment from "moment";
+import { formatDateLong, toISOString } from "@web-speed-hackathon-2026/client/src/utils/date_format";
 import { MouseEventHandler, useCallback } from "react";
 import { Link, useNavigate } from "react-router";
 
@@ -76,8 +76,8 @@ export const TimelineItem = ({ post }: Props) => {
             </Link>
             <span className="text-cax-text-muted pr-1">-</span>
             <Link className="text-cax-text-muted pr-1 hover:underline" to={`/posts/${post.id}`}>
-              <time dateTime={moment(post.createdAt).toISOString()}>
-                {moment(post.createdAt).locale("ja").format("LL")}
+              <time dateTime={toISOString(post.createdAt)}>
+                {formatDateLong(post.createdAt)}
               </time>
             </Link>
           </p>

--- a/application/client/src/components/user_profile/UserProfileHeader.tsx
+++ b/application/client/src/components/user_profile/UserProfileHeader.tsx
@@ -1,5 +1,5 @@
 import { FastAverageColor } from "fast-average-color";
-import moment from "moment";
+import { formatDateLong, toISOString } from "@web-speed-hackathon-2026/client/src/utils/date_format";
 import { ReactEventHandler, useCallback, useState } from "react";
 
 import { FontAwesomeIcon } from "@web-speed-hackathon-2026/client/src/components/foundation/FontAwesomeIcon";
@@ -43,8 +43,8 @@ export const UserProfileHeader = ({ user }: Props) => {
             <FontAwesomeIcon iconType="calendar-alt" styleType="regular" />
           </span>
           <span>
-            <time dateTime={moment(user.createdAt).toISOString()}>
-              {moment(user.createdAt).locale("ja").format("LL")}
+            <time dateTime={toISOString(user.createdAt)}>
+              {formatDateLong(user.createdAt)}
             </time>
             からサービスを利用しています
           </span>

--- a/application/client/src/utils/bm25_search.ts
+++ b/application/client/src/utils/bm25_search.ts
@@ -1,6 +1,5 @@
 import { BM25 } from "bayesian-bm25";
 import type { Tokenizer, IpadicFeatures } from "kuromoji";
-import _ from "lodash";
 
 const STOP_POS = new Set(["助詞", "助動詞", "記号"]);
 
@@ -28,15 +27,13 @@ export function filterSuggestionsBM25(
   const tokenizedCandidates = candidates.map((c) => extractTokens(tokenizer.tokenize(c)));
   bm25.index(tokenizedCandidates);
 
-  const results = _.zipWith(candidates, bm25.getScores(queryTokens), (text, score) => {
-    return { text, score };
-  });
-
-  // スコアが高い（＝類似度が高い）ものが下に来るように、上位10件を取得する
-  return _(results)
+  const scores = bm25.getScores(queryTokens) as number[];
+  const results = candidates
+    .map((text, i) => ({ text, score: scores[i] ?? 0 }))
     .filter((s) => s.score > 0)
-    .sortBy(["score"])
+    .sort((a, b) => a.score - b.score)
     .slice(-10)
-    .map((s) => s.text)
-    .value();
+    .map((s) => s.text);
+
+  return results;
 }

--- a/application/client/src/utils/create_translator.ts
+++ b/application/client/src/utils/create_translator.ts
@@ -1,4 +1,3 @@
-import { CreateMLCEngine } from "@mlc-ai/web-llm";
 import { stripIndents } from "common-tags";
 import * as JSONRepairJS from "json-repair-js";
 import langs from "langs";
@@ -21,6 +20,8 @@ export async function createTranslator(params: Params): Promise<Translator> {
   const targetLang = langs.where("1", params.targetLanguage);
   invariant(targetLang, `Unsupported target language code: ${params.targetLanguage}`);
 
+  // web-llm は巨大なので動的importでバンドルから分離する
+  const { CreateMLCEngine } = await import("@mlc-ai/web-llm");
   const engine = await CreateMLCEngine("gemma-2-2b-jpn-it-q4f16_1-MLC");
 
   return {

--- a/application/client/src/utils/date_format.ts
+++ b/application/client/src/utils/date_format.ts
@@ -1,0 +1,48 @@
+/**
+ * 日付フォーマットユーティリティ。
+ * moment.js の代替として Intl API を使用する。
+ */
+
+/** 日本語の年月日形式（例: "2026年3月20日"） */
+export function formatDateLong(date: string | Date): string {
+  return new Intl.DateTimeFormat("ja-JP", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(new Date(date));
+}
+
+/** 時分形式（例: "14:30"） */
+export function formatTime(date: string | Date): string {
+  return new Intl.DateTimeFormat("ja-JP", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(new Date(date));
+}
+
+/** 相対時間（例: "3時間前"） */
+export function timeAgo(date: string | Date): string {
+  const now = Date.now();
+  const diff = now - new Date(date).getTime();
+  const seconds = Math.floor(diff / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+  const months = Math.floor(days / 30);
+  const years = Math.floor(days / 365);
+
+  const rtf = new Intl.RelativeTimeFormat("ja", { numeric: "auto" });
+
+  if (years > 0) return rtf.format(-years, "year");
+  if (months > 0) return rtf.format(-months, "month");
+  if (days > 0) return rtf.format(-days, "day");
+  if (hours > 0) return rtf.format(-hours, "hour");
+  if (minutes > 0) return rtf.format(-minutes, "minute");
+  return rtf.format(-seconds, "second");
+}
+
+/** ISO文字列に変換する */
+export function toISOString(date: string | Date): string {
+  return new Date(date).toISOString();
+}

--- a/application/client/src/utils/fetchers.ts
+++ b/application/client/src/utils/fetchers.ts
@@ -1,58 +1,40 @@
-import $ from "jquery";
-import { gzip } from "pako";
+/**
+ * HTTP通信ユーティリティ。
+ * fetch APIを使用し、メインスレッドをブロックしない非同期通信を行う。
+ */
 
+/** 指定URLからバイナリデータを取得する */
 export async function fetchBinary(url: string): Promise<ArrayBuffer> {
-  const result = await $.ajax({
-    async: false,
-    dataType: "binary",
-    method: "GET",
-    responseType: "arraybuffer",
-    url,
-  });
-  return result;
+  const res = await fetch(url);
+  return res.arrayBuffer();
 }
 
+/** 指定URLからJSONデータを取得する */
 export async function fetchJSON<T>(url: string): Promise<T> {
-  const result = await $.ajax({
-    async: false,
-    dataType: "json",
-    method: "GET",
-    url,
-  });
-  return result;
+  const res = await fetch(url);
+  return res.json() as Promise<T>;
 }
 
+/** 指定URLにファイルをPOST送信する */
 export async function sendFile<T>(url: string, file: File): Promise<T> {
-  const result = await $.ajax({
-    async: false,
-    data: file,
-    dataType: "json",
+  const res = await fetch(url, {
+    method: "POST",
+    body: file,
     headers: {
       "Content-Type": "application/octet-stream",
     },
-    method: "POST",
-    processData: false,
-    url,
   });
-  return result;
+  return res.json() as Promise<T>;
 }
 
+/** 指定URLにJSONデータをPOST送信する */
 export async function sendJSON<T>(url: string, data: object): Promise<T> {
-  const jsonString = JSON.stringify(data);
-  const uint8Array = new TextEncoder().encode(jsonString);
-  const compressed = gzip(uint8Array);
-
-  const result = await $.ajax({
-    async: false,
-    data: compressed,
-    dataType: "json",
+  const res = await fetch(url, {
+    method: "POST",
+    body: JSON.stringify(data),
     headers: {
-      "Content-Encoding": "gzip",
       "Content-Type": "application/json",
     },
-    method: "POST",
-    processData: false,
-    url,
   });
-  return result;
+  return res.json() as Promise<T>;
 }

--- a/application/client/src/utils/negaposi_analyzer.ts
+++ b/application/client/src/utils/negaposi_analyzer.ts
@@ -1,10 +1,17 @@
-import Bluebird from "bluebird";
 import kuromoji, { type Tokenizer, type IpadicFeatures } from "kuromoji";
 import analyze from "negaposi-analyzer-ja";
 
-async function getTokenizer(): Promise<Tokenizer<IpadicFeatures>> {
-  const builder = Bluebird.promisifyAll(kuromoji.builder({ dicPath: "/dicts" }));
-  return await builder.buildAsync();
+/** kuromoji トークナイザーをPromiseで初期化する（Bluebird不要） */
+function getTokenizer(): Promise<Tokenizer<IpadicFeatures>> {
+  return new Promise((resolve, reject) => {
+    kuromoji.builder({ dicPath: "/dicts" }).build((err, tokenizer) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(tokenizer);
+      }
+    });
+  });
 }
 
 type SentimentResult = {
@@ -12,6 +19,7 @@ type SentimentResult = {
   label: "positive" | "negative" | "neutral";
 };
 
+/** テキストの感情分析を行い、スコアとラベルを返す */
 export async function analyzeSentiment(text: string): Promise<SentimentResult> {
   const tokenizer = await getTokenizer();
   const tokens = tokenizer.tokenize(text);

--- a/application/client/webpack.config.js
+++ b/application/client/webpack.config.js
@@ -28,9 +28,6 @@ const config = {
   devtool: false,
   entry: {
     main: [
-      "core-js",
-      "regenerator-runtime/runtime",
-      "jquery-binarytransport",
       path.resolve(SRC_PATH, "./index.css"),
       path.resolve(SRC_PATH, "./buildinfo.ts"),
       path.resolve(SRC_PATH, "./index.tsx"),
@@ -70,10 +67,8 @@ const config = {
   },
   plugins: [
     new webpack.ProvidePlugin({
-      $: "jquery",
       AudioContext: ["standardized-audio-context", "AudioContext"],
       Buffer: ["buffer", "Buffer"],
-      "window.jQuery": "jquery",
     }),
     new webpack.EnvironmentPlugin({
       BUILD_DATE: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- core-js / regenerator-runtime / jquery-binarytransport をエントリから除去
- jQuery → fetch API（同期AJAX解消、#5も同時解決）
- Bluebird → ネイティブPromise/コールバック
- moment.js → Intl API（date_format.ts新規作成）
- lodash → ネイティブ配列メソッド
- pako（gzip）→ 除去
- web-llm → 動的import
- ProvidePlugin から jQuery 関連除去

## Test plan
- [x] `pnpm build` 成功
- [ ] 各ページの日付表示が正しいこと
- [ ] DM送信・検索・投稿機能が正常動作すること

Closes #2
Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)