### PR TITLE
fix: SearchInputにaria-labelを追加して検索テストを修復

### DIFF
--- a/application/client/src/components/application/SearchPage.tsx
+++ b/application/client/src/components/application/SearchPage.tsx
@@ -22,6 +22,7 @@ const SearchInput = ({ input, meta }: WrappedFieldProps) => (
   <div className="flex flex-1 flex-col">
     <input
       {...input}
+      aria-label="検索 (例: キーワード since:2025-01-01 until:2025-12-31)"
       className={`flex-1 rounded border px-4 py-2 focus:outline-none ${
         meta.touched && meta.error
           ? "border-cax-danger focus:border-cax-danger"


### PR DESCRIPTION
## 概要
scoring-toolのユーザーフローテスト「検索→結果表示」が計測不可だった問題を修正。

## 変更内容
- `SearchInput`コンポーネントに`aria-label`属性を追加
- Playwrightの`getByRole("textbox", { name: "検索 ..." })`で検出可能に

## 根本原因
`<input>`に`<label>`も`aria-label`もなく、`placeholder`だけではアクセシブルネームとして認識されないため、Playwrightがtextboxを見つけられなかった。

## 検証手順
1. `pnpm start` でサーバー起動
2. scoring-toolで検索フローテストを実行
3. 「検索クエリの入力に失敗しました」エラーが出ないことを確認

Closes #29