### PR TITLE
fix: メディア変換失敗時の投稿ボタンスタックを防止

### DIFF
--- a/application/client/src/components/new_post_modal/NewPostModalPage.tsx
+++ b/application/client/src/components/new_post_modal/NewPostModalPage.tsx
@@ -70,7 +70,10 @@ export const NewPostModalPage = ({ id, hasError, isLoading, onResetError, onSubm
 
           setIsConverting(false);
         })
-        .catch(console.error);
+        .catch((err) => {
+          console.error(err);
+          setIsConverting(false);
+        });
     }
   }, []);
 
@@ -82,16 +85,21 @@ export const NewPostModalPage = ({ id, hasError, isLoading, onResetError, onSubm
     if (isValid) {
       setIsConverting(true);
 
-      convertSound(file, { extension: "mp3" }).then((converted) => {
-        setParams((params) => ({
-          ...params,
-          images: [],
-          movie: undefined,
-          sound: new File([converted], "converted.mp3", { type: "audio/mpeg" }),
-        }));
+      convertSound(file, { extension: "mp3" })
+        .then((converted) => {
+          setParams((params) => ({
+            ...params,
+            images: [],
+            movie: undefined,
+            sound: new File([converted], "converted.mp3", { type: "audio/mpeg" }),
+          }));
 
-        setIsConverting(false);
-      });
+          setIsConverting(false);
+        })
+        .catch((err) => {
+          console.error(err);
+          setIsConverting(false);
+        });
     }
   }, []);
 
@@ -116,7 +124,10 @@ export const NewPostModalPage = ({ id, hasError, isLoading, onResetError, onSubm
 
           setIsConverting(false);
         })
-        .catch(console.error);
+        .catch((err) => {
+          console.error(err);
+          setIsConverting(false);
+        });
     }
   }, []);
 


### PR DESCRIPTION
## 概要
scoring-toolのユーザーフローテスト「投稿」が計測不可だった問題を修正。

## 変更内容
- 画像変換の`.catch`に`setIsConverting(false)`を追加
- 音声変換に`.catch`ハンドラを追加（`setIsConverting(false)`含む）
- 動画変換の`.catch`に`setIsConverting(false)`を追加

## 根本原因
FFmpeg/ImageMagick WASMの読み込みや変換が失敗した場合、`.catch`内で`setIsConverting(false)`が呼ばれず、投稿ボタンが`disabled={isConverting}`で永遠に無効化されていた。scoring-toolは120秒待機後タイムアウト。

## 検証手順
1. `pnpm start` でサーバー起動
2. scoring-toolで投稿フローテストを実行
3. 「動画投稿の完了を確認できませんでした」エラーが出ないことを確認

Closes #30