### PR TITLE
perf: AspectRatioBoxのCSS aspect-ratio化 + CoveredImageサイズヒント

### DIFF
--- a/application/client/src/components/foundation/AspectRatioBox.tsx
+++ b/application/client/src/components/foundation/AspectRatioBox.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useRef, useState } from "react";
+import { ReactNode } from "react";
 
 interface Props {
   aspectHeight: number;
@@ -7,31 +7,14 @@ interface Props {
 }
 
 /**
- * 親要素の横幅を基準にして、指定したアスペクト比のブロック要素を作ります
+ * 親要素の横幅を基準にして、指定したアスペクト比のブロック要素を作る。
+ * CSS aspect-ratioプロパティで即座にレイアウトが確定するため、
+ * JS計算による500ms遅延とCLSを排除する。
  */
 export const AspectRatioBox = ({ aspectHeight, aspectWidth, children }: Props) => {
-  const ref = useRef<HTMLDivElement>(null);
-  const [clientHeight, setClientHeight] = useState(0);
-
-  useEffect(() => {
-    // clientWidth とアスペクト比から clientHeight を計算する
-    function calcStyle() {
-      const clientWidth = ref.current?.clientWidth ?? 0;
-      setClientHeight((clientWidth / aspectWidth) * aspectHeight);
-    }
-    setTimeout(() => calcStyle(), 500);
-
-    // ウィンドウサイズが変わるたびに計算する
-    window.addEventListener("resize", calcStyle, { passive: false });
-    return () => {
-      window.removeEventListener("resize", calcStyle);
-    };
-  }, [aspectHeight, aspectWidth]);
-
   return (
-    <div ref={ref} className="relative h-1 w-full" style={{ height: clientHeight }}>
-      {/* 高さが計算できるまで render しない */}
-      {clientHeight !== 0 ? <div className="absolute inset-0">{children}</div> : null}
+    <div className="relative w-full" style={{ aspectRatio: `${aspectWidth} / ${aspectHeight}` }}>
+      <div className="absolute inset-0">{children}</div>
     </div>
   );
 };

--- a/application/client/src/components/foundation/CoveredImage.tsx
+++ b/application/client/src/components/foundation/CoveredImage.tsx
@@ -25,6 +25,8 @@ export const CoveredImage = ({ alt, src }: Props) => {
       <img
         alt={alt}
         className="h-full w-full object-cover"
+        width={640}
+        height={360}
         loading="lazy"
         decoding="async"
         src={src}


### PR DESCRIPTION
## Summary
- AspectRatioBoxのJS計算+setTimeout(500ms)をCSS `aspect-ratio`に置き換え
- CoveredImageにwidth/height属性追加でLCP改善

## Test plan
- [ ] 画像・動画・音声の表示領域が正しいアスペクト比で表示される
- [ ] 500ms遅延なしで即座にレイアウトが確定する

Refs #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)