### PR TITLE
fix: Crok SSE・画像表示・サーバー起動の修正

### DIFF
--- a/application/client/src/components/foundation/CoveredImage.tsx
+++ b/application/client/src/components/foundation/CoveredImage.tsx
@@ -27,7 +27,6 @@ export const CoveredImage = ({ alt, src }: Props) => {
         className="h-full w-full object-cover"
         width={640}
         height={360}
-        loading="lazy"
         decoding="async"
         src={src}
       />

--- a/application/server/src/app.ts
+++ b/application/server/src/app.ts
@@ -10,8 +10,15 @@ export const app = Express();
 
 app.set("trust proxy", true);
 
-// gzip圧縮でレスポンスサイズを削減する
-app.use(compression());
+// gzip圧縮でレスポンスサイズを削減する（SSEはバッファリングすると送信が止まるため除外）
+app.use(compression({
+  filter: (req, res) => {
+    if (res.getHeader("Content-Type") === "text/event-stream") {
+      return false;
+    }
+    return compression.filter(req, res);
+  },
+}));
 
 app.use(sessionMiddleware);
 app.use(bodyParser.json());

--- a/application/server/src/routes/api/image.ts
+++ b/application/server/src/routes/api/image.ts
@@ -4,7 +4,7 @@ import path from "path";
 import { Router } from "express";
 import { fileTypeFromBuffer } from "file-type";
 import httpErrors from "http-errors";
-import { load, ImageIFD } from "piexifjs";
+import piexif from "piexifjs";
 import { v4 as uuidv4 } from "uuid";
 
 import { UPLOAD_PATH } from "@web-speed-hackathon-2026/server/src/paths";
@@ -19,8 +19,8 @@ const EXTENSION = "jpg";
 function extractAltFromExif(buffer: Buffer): string {
   try {
     const binary = buffer.toString("binary");
-    const exif = load(binary);
-    const raw = exif?.["0th"]?.[ImageIFD.ImageDescription];
+    const exif = piexif.load(binary);
+    const raw = exif?.["0th"]?.[piexif.ImageIFD.ImageDescription];
     if (raw != null) {
       return new TextDecoder().decode(Buffer.from(raw as string, "binary"));
     }

--- a/application/server/src/types/piexifjs.d.ts
+++ b/application/server/src/types/piexifjs.d.ts
@@ -1,9 +1,12 @@
 declare module "piexifjs" {
-  export const ImageIFD: {
-    ImageDescription: number;
-    [key: string]: number;
+  const piexif: {
+    ImageIFD: {
+      ImageDescription: number;
+      [key: string]: number;
+    };
+    load(data: string): Record<string, Record<number, unknown>>;
+    dump(exifObj: Record<string, Record<number, unknown>>): string;
+    insert(exifStr: string, jpegData: string): string;
   };
-  export function load(data: string): Record<string, Record<number, unknown>>;
-  export function dump(exifObj: Record<string, Record<number, unknown>>): string;
-  export function insert(exifStr: string, jpegData: string): string;
+  export default piexif;
 }


### PR DESCRIPTION
## Summary
- SSEをgzip圧縮から除外（Crokチャットの応答が返らない問題を修正）
- CoveredImageのloading="lazy"削除（投稿直後の画像非表示を修正）
- piexifjsのESM import修正（サーバー起動エラーを修正）

## Test plan
- [ ] Crok AIチャットで応答が返ってくる
- [ ] 画像投稿後、詳細ページで画像が表示される
- [ ] サーバーが正常起動する

🤖 Generated with [Claude Code](https://claude.com/claude-code)