### PR TITLE
fix: 検索フォームのredux-form除去でscoring-tool入力安定化

### DIFF
--- a/application/client/src/components/application/SearchPage.tsx
+++ b/application/client/src/components/application/SearchPage.tsx
@@ -1,14 +1,18 @@
-import { useEffect, useMemo, useState } from "react";
+/**
+ * 検索ページコンポーネント。
+ * redux-formを排除し、useState + onSubmitで検索フォームを管理する。
+ * Playwrightのaria-label検出とpressSequentially入力の安定性を確保するため、
+ * 非制御コンポーネントとして実装。
+ */
+import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router";
-import { Field, InjectedFormProps, reduxForm, WrappedFieldProps } from "redux-form";
 
 import { Timeline } from "@web-speed-hackathon-2026/client/src/components/timeline/Timeline";
 import {
   parseSearchQuery,
   sanitizeSearchText,
+  isValidDate,
 } from "@web-speed-hackathon-2026/client/src/search/services";
-import { SearchFormData } from "@web-speed-hackathon-2026/client/src/search/types";
-import { validate } from "@web-speed-hackathon-2026/client/src/search/validation";
 import { analyzeSentiment } from "@web-speed-hackathon-2026/client/src/utils/negaposi_analyzer";
 
 import { Button } from "../foundation/Button";
@@ -18,31 +22,10 @@ interface Props {
   results: Models.Post[];
 }
 
-const SearchInput = ({ input, meta }: WrappedFieldProps) => (
-  <div className="flex flex-1 flex-col">
-    <input
-      {...input}
-      aria-label="検索 (例: キーワード since:2025-01-01 until:2025-12-31)"
-      className={`flex-1 rounded border px-4 py-2 focus:outline-none ${
-        meta.touched && meta.error
-          ? "border-cax-danger focus:border-cax-danger"
-          : "border-cax-border focus:border-cax-brand-strong"
-      }`}
-      placeholder="検索 (例: キーワード since:2025-01-01 until:2025-12-31)"
-      type="text"
-    />
-    {meta.touched && meta.error && (
-      <span className="text-cax-danger mt-1 text-xs">{meta.error}</span>
-    )}
-  </div>
-);
-
-const SearchPageComponent = ({
-  query,
-  results,
-  handleSubmit,
-}: Props & InjectedFormProps<SearchFormData, Props>) => {
+export const SearchPage = ({ query, results }: Props) => {
   const navigate = useNavigate();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [error, setError] = useState<string | null>(null);
   const [isNegative, setIsNegative] = useState(false);
 
   const parsed = parseSearchQuery(query);
@@ -85,17 +68,63 @@ const SearchPageComponent = ({
     return parts.join(" ");
   }, [parsed]);
 
-  const onSubmit = (values: SearchFormData) => {
-    const sanitizedText = sanitizeSearchText(values.searchText.trim());
-    navigate(`/search?q=${encodeURIComponent(sanitizedText)}`);
-  };
+  /** フォーム送信時にバリデーション→ナビゲーション */
+  const handleSubmit = useCallback(
+    (e: FormEvent) => {
+      e.preventDefault();
+      const raw = inputRef.current?.value.trim() || "";
+
+      if (!raw) {
+        setError("検索キーワードを入力してください");
+        return;
+      }
+
+      const { keywords, sinceDate, untilDate } = parseSearchQuery(raw);
+
+      if (!keywords && !sinceDate && !untilDate) {
+        setError("検索キーワードまたは日付範囲を指定してください");
+        return;
+      }
+      if (sinceDate && !isValidDate(sinceDate)) {
+        setError(`since: の日付形式が不正です: ${sinceDate}`);
+        return;
+      }
+      if (untilDate && !isValidDate(untilDate)) {
+        setError(`until: の日付形式が不正です: ${untilDate}`);
+        return;
+      }
+      if (sinceDate && untilDate && new Date(sinceDate) > new Date(untilDate)) {
+        setError("since: は until: より前の日付を指定してください");
+        return;
+      }
+
+      setError(null);
+      const sanitizedText = sanitizeSearchText(raw);
+      navigate(`/search?q=${encodeURIComponent(sanitizedText)}`);
+    },
+    [navigate],
+  );
 
   return (
     <div className="flex flex-col gap-4">
       <div className="bg-cax-surface p-4 shadow">
-        <form onSubmit={handleSubmit(onSubmit)}>
+        <form onSubmit={handleSubmit}>
           <div className="flex gap-2">
-            <Field name="searchText" component={SearchInput} />
+            <div className="flex flex-1 flex-col">
+              <input
+                ref={inputRef}
+                aria-label="検索 (例: キーワード since:2025-01-01 until:2025-12-31)"
+                className={`flex-1 rounded border px-4 py-2 focus:outline-none ${
+                  error
+                    ? "border-cax-danger focus:border-cax-danger"
+                    : "border-cax-border focus:border-cax-brand-strong"
+                }`}
+                defaultValue={query}
+                placeholder="検索 (例: キーワード since:2025-01-01 until:2025-12-31)"
+                type="text"
+              />
+              {error && <span className="text-cax-danger mt-1 text-xs">{error}</span>}
+            </div>
             <Button variant="primary" type="submit">
               検索
             </Button>
@@ -135,9 +164,3 @@ const SearchPageComponent = ({
     </div>
   );
 };
-
-export const SearchPage = reduxForm<SearchFormData, Props>({
-  form: "search",
-  enableReinitialize: true,
-  validate,
-})(SearchPageComponent);

--- a/application/client/src/containers/SearchContainer.tsx
+++ b/application/client/src/containers/SearchContainer.tsx
@@ -20,7 +20,7 @@ export const SearchContainer = () => {
       <Helmet>
         <title>検索 - CaX</title>
       </Helmet>
-      <SearchPage query={query} results={posts} initialValues={{ searchText: query }} />
+      <SearchPage query={query} results={posts} />
     </InfiniteScroll>
   );
 };


### PR DESCRIPTION
## Summary
- 検索フォームのredux-formを除去し、useState+refの非制御コンポーネントに置き換え
- PlaywrightのpressSequentiallyとredux-formのkeystroke再レンダリング競合を解消

## Related Issue
Closes #29

## Changes
- `SearchPage.tsx`: redux-form(reduxForm HOC, Field, WrappedFieldProps)を除去、useRef+defaultValueで非制御input化
- `SearchContainer.tsx`: initialValuesプロパティの除去
- バリデーションはsubmit時のみ実行（aria-label・placeholder・エラー表示は維持）

## Test Plan
- [ ] ビルド成功を確認 ✅
- [ ] scoring-tool `--targetName "検索 → 結果表示"` でテスト通過を確認
- [ ] 手動で検索機能が正常に動作することを確認
- [ ] バリデーション（空入力、不正日付）が機能することを確認

## Rollback
問題があれば `git revert` で戻せます

🤖 Generated with [Claude Code](https://claude.com/claude-code)