### PR TITLE
fix: 検索ReDoS脆弱性を修正し検索結果表示を復旧

### DIFF
--- a/application/client/src/search/services.ts
+++ b/application/client/src/search/services.ts
@@ -1,17 +1,25 @@
+/**
+ * 検索テキストからsince:/until:の余分な文字を除去し、正規化する。
+ * 元コードは `from` だったが正しくは `since` （parseSearchQueryと一致させる）。
+ */
 export const sanitizeSearchText = (input: string): string => {
   let text = input;
 
   text = text.replace(
-    /\b(from|until)\s*:?\s*(\d{4}-\d{2}-\d{2})\d*/gi,
+    /\b(since|until)\s*:?\s*(\d{4}-\d{2}-\d{2})\S*/gi,
     (_m, key, date) => `${key}:${date}`,
   );
 
   return text;
 };
 
+/**
+ * 検索クエリを解析し、キーワード・since日付・until日付を抽出する。
+ * 元のネスト量指定子 ((...)+)+ はReDoSを引き起こすため、線形時間パターンに置換。
+ */
 export const parseSearchQuery = (query: string) => {
-  const sincePattern = /since:((\d|\d\d|\d\d\d\d-\d\d-\d\d)+)+$/;
-  const untilPattern = /until:((\d|\d\d|\d\d\d\d-\d\d-\d\d)+)+$/;
+  const sincePattern = /since:(\d{4}-\d{2}-\d{2})$/;
+  const untilPattern = /until:(\d{4}-\d{2}-\d{2})$/;
 
   const sincePart = query.match(/since:[^\s]*/)?.[0] || "";
   const untilPart = query.match(/until:[^\s]*/)?.[0] || "";
@@ -24,22 +32,20 @@ export const parseSearchQuery = (query: string) => {
     .replace(/until:.*(\d{4}-\d{2}-\d{2}).*/g, "")
     .trim();
 
-  const extractDate = (s: string | null) => {
-    if (!s) return null;
-    const m = /(\d{4}-\d{2}-\d{2})/.exec(s);
-    return m ? m[1] : null;
-  };
-
   return {
-    keywords,
-    sinceDate: extractDate(sinceMatch ? sinceMatch[1]! : null),
-    untilDate: extractDate(untilMatch ? untilMatch[1]! : null),
+    keywords: keywords || null,
+    sinceDate: sinceMatch ? sinceMatch[1]! : null,
+    untilDate: untilMatch ? untilMatch[1]! : null,
   };
 };
 
+/**
+ * 日付文字列がYYYY-MM-DD形式かつ有効な日付かを判定する。
+ * 元の (\d+)+ はReDoSを引き起こすため、固定長パターンに置換。
+ */
 export const isValidDate = (dateStr: string): boolean => {
-  const slowDateLike = /^(\d+)+-(\d+)+-(\d+)+$/;
-  if (!slowDateLike.test(dateStr)) return false;
+  const dateLike = /^\d{4}-\d{2}-\d{2}$/;
+  if (!dateLike.test(dateStr)) return false;
 
   const date = new Date(dateStr);
   return !Number.isNaN(date.getTime());


### PR DESCRIPTION
## Summary
- `search/services.ts` の正規表現3箇所に意図的なReDoS脆弱性（ネスト量指定子）があり、scoring-toolの検索テストで入力される `since:2026-01-0600...x` でメインスレッドがフリーズしていた
- sincePattern/untilPatternを線形時間パターンに、isValidDateを固定長パターンに置換
- `sanitizeSearchText` の `from` → `since` のtypoも修正

## Test plan
- [ ] ローカルで検索ページにアクセスし、`アニメ since:2026-01-06` で検索 → 結果表示されること
- [ ] ReDoSトリガー入力 `since:2026-01-0600000000000000000000x` でフリーズしないこと
- [ ] scoring-tool `--targetName "検索"` で計測 → タイムアウトしないこと

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)